### PR TITLE
#18 [feat] 챗봇 호출 및 결과 반환 기능 개발

### DIFF
--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/constants/AnswerType.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/constants/AnswerType.java
@@ -1,0 +1,9 @@
+package com.skku.fixskku.chatbot.constants;
+
+public enum AnswerType {
+    FAQ, // faq 조회
+    NORMAL, // 일반 질문
+    FAC, // 강의실 정보 조회
+    REPORT, // 신고
+    MYREPORT // 자신의 신고 조회
+}

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/constants/ChatbotUrl.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/constants/ChatbotUrl.java
@@ -1,0 +1,5 @@
+package com.skku.fixskku.chatbot.constants;
+
+public final class ChatbotUrl {
+    public static final String CHATBOT_SERVER = "https://beetle-prompt-finally.ngrok-free.app/chat/";
+}

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/constants/ChatbotUrl.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/constants/ChatbotUrl.java
@@ -2,4 +2,8 @@ package com.skku.fixskku.chatbot.constants;
 
 public final class ChatbotUrl {
     public static final String CHATBOT_SERVER = "https://beetle-prompt-finally.ngrok-free.app/chat/";
+    public static final String FACILITY_INFO_URI = ""; // 시설물 조회 URI
+    public static final String REPORT_URI = ""; // 신고 URI
+    public static final String MYREPORT_URI = ""; // 자신의 신고 조회 URI
+
 }

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/controller/ChatbotController.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/controller/ChatbotController.java
@@ -33,10 +33,13 @@ public class ChatbotController {
                 return ResponseApi.serverError();
             }
         }
-        else {
-
+        // 2. 일반 질문, 신고, 자신의 신고 조회, 시설물 조회의 경우
+        try {
+            return chatbotService.sendToChatbotAndGetAnswer(tokenId, text);
+        }catch (GeneralException e) {
+            return ResponseApi.of(e.getStatus());
+        } catch (Exception e) {
+            return ResponseApi.serverError();
         }
-        return null;
     }
-
 }

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/controller/ChatbotController.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/controller/ChatbotController.java
@@ -1,0 +1,42 @@
+package com.skku.fixskku.chatbot.controller;
+
+import com.skku.fixskku.chatbot.service.ChatbotService;
+import com.skku.fixskku.common.apipayload.ResponseApi;
+import com.skku.fixskku.common.apipayload.ResponseStatus;
+import com.skku.fixskku.common.apipayload.exception.GeneralException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/chatbot")
+@Slf4j
+public class ChatbotController {
+
+    private final ChatbotService chatbotService;
+
+    public ChatbotController(ChatbotService chatbotService) {
+        this.chatbotService = chatbotService;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> getTextFromUser(@RequestHeader(name = "token")String tokenId,
+                                             @RequestParam(name = "faq", required = false) Long faqId, String text){
+        // 1. 챗봇을 통해 FAQ를 물어본 경우(프론트에서 FAQ 버튼을 클릭)
+        if(faqId!=null){
+            try {
+                chatbotService.faqRequest(tokenId, faqId, text);
+                return ResponseApi.of(ResponseStatus._CHATBOT_FAQ_SUCCESS,null);
+            }catch (GeneralException e) {
+                return ResponseApi.of(e.getStatus());
+            } catch (Exception e) {
+                return ResponseApi.serverError();
+            }
+        }
+        else {
+
+        }
+        return null;
+    }
+
+}

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/req/ToChatbotReqDto.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/req/ToChatbotReqDto.java
@@ -1,4 +1,4 @@
-package com.skku.fixskku.chatbot.dto.res;
+package com.skku.fixskku.chatbot.dto.req;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/ChatbotResDto.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/ChatbotResDto.java
@@ -1,0 +1,28 @@
+package com.skku.fixskku.chatbot.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.skku.fixskku.chatbot.constants.AnswerType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+@AllArgsConstructor
+public class ChatbotResDto {
+
+    @JsonProperty("answerType")
+    private AnswerType answerType;
+
+    @JsonProperty("text")
+    private String text;
+
+    @JsonProperty("FAQ_id")
+    private long faqId;
+
+    @JsonProperty("data")
+    private FromChatbotResDataDto data;
+
+}

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/FromChatbotResDataDto.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/FromChatbotResDataDto.java
@@ -1,20 +1,22 @@
 package com.skku.fixskku.chatbot.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Data
 @Getter
 @Setter
 @AllArgsConstructor
+@RequiredArgsConstructor
 public class FromChatbotResDataDto {
-    private long classroom;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private String broken_item;
+    private String campus;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String building;
+
+    private String classroom;
 
 }
 

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/FromChatbotResDataDto.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/FromChatbotResDataDto.java
@@ -1,0 +1,20 @@
+package com.skku.fixskku.chatbot.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+@AllArgsConstructor
+public class FromChatbotResDataDto {
+    private long classroom;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String broken_item;
+
+}
+

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/ToChatbotReqDto.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/ToChatbotReqDto.java
@@ -1,0 +1,21 @@
+package com.skku.fixskku.chatbot.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+@AllArgsConstructor
+public class ToChatbotReqDto {
+
+    @JsonProperty("text")
+    private String text;
+
+    @JsonProperty("FAQ_id")
+    private long faqId;
+
+}

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/ToChatbotReqDto.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/ToChatbotReqDto.java
@@ -16,6 +16,6 @@ public class ToChatbotReqDto {
     private String text;
 
     @JsonProperty("FAQ_id")
-    private long faqId;
+    private String faqId;
 
 }

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/ToFrontResDto.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/dto/res/ToFrontResDto.java
@@ -1,0 +1,29 @@
+package com.skku.fixskku.chatbot.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Data
+public class ToFrontResDto {
+
+    @JsonProperty("response")
+    private String response;
+
+    @JsonProperty("uri")
+    private String uri;
+
+    @JsonProperty("campus")
+    private String campus;
+
+    @JsonProperty("building")
+    private String building;
+
+    @JsonProperty("classroom")
+    private String classroom;
+}

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
@@ -43,4 +43,11 @@ public interface ChatbotService {
      * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
      */
     ResponseEntity<?> returnReportForm(ChatbotResDto dto);
+
+    /**
+     * 챗봇 자신의 신고 조회 기능
+     * @param dto 챗봇으로부터 받은 응답 DTO
+     * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
+     */
+    ResponseEntity<?> returnMyReportForm(ChatbotResDto dto);
 }

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
@@ -1,5 +1,7 @@
 package com.skku.fixskku.chatbot.service;
 
+import com.skku.fixskku.chatbot.dto.res.ChatbotResDto;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,4 +14,19 @@ public interface ChatbotService {
      * @param text faq 응답 내용
      */
     void faqRequest(String tokenId, long faqId, String text);
+
+    /**
+     * FAQ를 제외한 모든 챗봇 기능 요청을 챗봇으로 전달하고 응답을 API 명세에 맞게 가져오는 기능
+     * @param tokenId 사용자의 토큰 아이디
+     * @param text 사용자의 입력 텍스트
+     * @return API 명세에 따른 응답 객체
+     */
+    ResponseEntity<?> sendToChatbotAndGetAnswer(String tokenId, String text);
+
+    /**
+     * 챗봇 일반 질문 기능
+     * @param dto 챗봇으로부터 받은 응답 DTO
+     * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
+     */
+    ResponseEntity<?> returnNormalQuestion(ChatbotResDto dto);
 }

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
@@ -29,4 +29,11 @@ public interface ChatbotService {
      * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
      */
     ResponseEntity<?> returnNormalQuestion(ChatbotResDto dto);
+
+    /**
+     * 챗봇 시설물 조회 기능
+     * @param dto 챗봇으로부터 받은 응답 DTO
+     * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
+     */
+    ResponseEntity<?> returnFacilityInfo(ChatbotResDto dto);
 }

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
@@ -1,0 +1,15 @@
+package com.skku.fixskku.chatbot.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ChatbotService {
+
+    /**
+     * 챗봇 FAQ 기능
+     * @param tokenId 사용자의 토큰 아이디
+     * @param faqId 사용자가 요청한 faq 아이디
+     * @param text faq 응답 내용
+     */
+    void faqRequest(String tokenId, long faqId, String text);
+}

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotService.java
@@ -36,4 +36,11 @@ public interface ChatbotService {
      * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
      */
     ResponseEntity<?> returnFacilityInfo(ChatbotResDto dto);
+
+    /**
+     * 챗봇 신고 기능
+     * @param dto 챗봇으로부터 받은 응답 DTO
+     * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
+     */
+    ResponseEntity<?> returnReportForm(ChatbotResDto dto);
 }

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
@@ -2,11 +2,17 @@ package com.skku.fixskku.chatbot.service;
 
 import com.skku.fixskku.chatbot.constants.ChatbotUrl;
 import com.skku.fixskku.chatbot.dto.res.ChatbotResDto;
-import com.skku.fixskku.chatbot.dto.res.ToChatbotReqDto;
+import com.skku.fixskku.chatbot.dto.req.ToChatbotReqDto;
+import com.skku.fixskku.chatbot.dto.res.ToFrontResDto;
+import com.skku.fixskku.common.apipayload.ResponseApi;
+import com.skku.fixskku.common.apipayload.ResponseStatus;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.Objects;
 
 @Service
 public class ChatbotServiceImpl implements ChatbotService{
@@ -26,6 +32,42 @@ public class ChatbotServiceImpl implements ChatbotService{
         // 요청 객체 생성
         HttpEntity<ToChatbotReqDto> request = new HttpEntity<>(reqDto, headers);
         restTemplate.postForEntity(ChatbotUrl.CHATBOT_SERVER, request, ChatbotResDto.class);
+    }
+
+    /**
+     * FAQ를 제외한 모든 챗봇 기능 요청을 챗봇으로 전달하고 응답을 API 명세에 맞게 가져오는 기능
+     * @param tokenId 사용자의 토큰 아이디
+     * @param text 사용자의 입력 텍스트
+     * @return API 명세에 따른 응답 객체
+     */
+    @Override
+    public ResponseEntity<?> sendToChatbotAndGetAnswer(String tokenId, String text) {
+        // 텍스트를 챗봇에게 전달
+        ToChatbotReqDto reqDto = new ToChatbotReqDto(text, null);
+        // 요청에 추가할 헤더 설정
+        HttpHeaders headers = setHttpHeaders(tokenId);
+        // 요청 객체 생성
+        HttpEntity<ToChatbotReqDto> request = new HttpEntity<>(reqDto, headers);
+        ResponseEntity<ChatbotResDto> chatbotResponse = restTemplate.postForEntity(ChatbotUrl.CHATBOT_SERVER, request, ChatbotResDto.class);
+        switch (Objects.requireNonNull(chatbotResponse.getBody()).getAnswerType()){
+            // 챗봇 일반 질문 기능
+            case NORMAL -> {
+                return returnNormalQuestion(chatbotResponse.getBody());
+            }
+
+        }
+
+        return null;
+    }
+
+    /**
+     * 챗봇 일반 질문 기능
+     * @param dto 챗봇으로부터 받은 응답 DTO
+     * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
+     */
+    public ResponseEntity<?> returnNormalQuestion(ChatbotResDto dto){
+        ToFrontResDto resDto = new ToFrontResDto(dto.getText(), null, null, null, null);
+        return ResponseApi.of(ResponseStatus._CHATBOT_NORMAL_SUCCESS,resDto);
     }
 
     /**

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
@@ -58,6 +58,10 @@ public class ChatbotServiceImpl implements ChatbotService{
             case FAC -> {
                 return returnFacilityInfo(chatbotResponse.getBody());
             }
+            // 챗봇 신고 기능
+            case REPORT -> {
+                return returnReportForm(chatbotResponse.getBody());
+            }
 
         }
 
@@ -70,7 +74,8 @@ public class ChatbotServiceImpl implements ChatbotService{
      * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
      */
     public ResponseEntity<?> returnNormalQuestion(ChatbotResDto dto){
-        ToFrontResDto resDto = new ToFrontResDto(dto.getText(), null, null, null, null);
+        ToFrontResDto resDto = new ToFrontResDto(
+                dto.getText(), null, null, null, null);
         return ResponseApi.of(ResponseStatus._CHATBOT_NORMAL_SUCCESS,resDto);
     }
 
@@ -90,6 +95,21 @@ public class ChatbotServiceImpl implements ChatbotService{
     }
 
     /**
+     * 챗봇 신고 기능
+     * @param dto 챗봇으로부터 받은 응답 DTO
+     * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
+     */
+    public ResponseEntity<?> returnReportForm(ChatbotResDto dto){
+        ToFrontResDto resDto = new ToFrontResDto(
+                null,
+                ChatbotUrl.REPORT_URI,
+                dto.getData().getCampus(),
+                dto.getData().getBuilding(),
+                dto.getData().getClassroom());
+        return ResponseApi.of(ResponseStatus._CHATBOT_FAC_SUCCESS,resDto);
+    }
+
+    /**
      * 챗봇 서버에게 요청 시 필요한 헤더를 설정하는 메서드
      * @param tokenId 사용자의 토큰 아이디
      * @return 완성된 HTTP 헤더
@@ -102,4 +122,6 @@ public class ChatbotServiceImpl implements ChatbotService{
         headers.add("token", tokenId);
         return headers;
     }
+
+
 }

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
@@ -1,0 +1,44 @@
+package com.skku.fixskku.chatbot.service;
+
+import com.skku.fixskku.chatbot.constants.ChatbotUrl;
+import com.skku.fixskku.chatbot.dto.res.ChatbotResDto;
+import com.skku.fixskku.chatbot.dto.res.ToChatbotReqDto;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class ChatbotServiceImpl implements ChatbotService{
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    /**
+     * 챗봇 FAQ 기능
+     * @param tokenId 사용자의 토큰 아이디
+     * @param faqId 사용자가 요청한 faq 아이디
+     * @param text faq 응답 내용
+     */
+    @Override
+    public void faqRequest(String tokenId, long faqId, String text) {
+        ToChatbotReqDto reqDto = new ToChatbotReqDto(text, faqId);
+        // 요청에 추가할 헤더 설정
+        HttpHeaders headers = setHttpHeaders(tokenId);
+        // 요청 객체 생성
+        HttpEntity<ToChatbotReqDto> request = new HttpEntity<>(reqDto, headers);
+        restTemplate.postForEntity(ChatbotUrl.CHATBOT_SERVER, request, ChatbotResDto.class);
+    }
+
+    /**
+     * 챗봇 서버에게 요청 시 필요한 헤더를 설정하는 메서드
+     * @param tokenId 사용자의 토큰 아이디
+     * @return 완성된 HTTP 헤더
+     */
+    private static HttpHeaders setHttpHeaders(String tokenId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("ngrok-skip-browser-warning", "69420");
+        headers.add("accept", "application/json");
+        headers.add("Content-Type", "application/json");
+        headers.add("token", tokenId);
+        return headers;
+    }
+}

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
@@ -20,7 +20,7 @@ public class ChatbotServiceImpl implements ChatbotService{
      */
     @Override
     public void faqRequest(String tokenId, long faqId, String text) {
-        ToChatbotReqDto reqDto = new ToChatbotReqDto(text, faqId);
+        ToChatbotReqDto reqDto = new ToChatbotReqDto(text, faqId+"");
         // 요청에 추가할 헤더 설정
         HttpHeaders headers = setHttpHeaders(tokenId);
         // 요청 객체 생성

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
@@ -54,6 +54,10 @@ public class ChatbotServiceImpl implements ChatbotService{
             case NORMAL -> {
                 return returnNormalQuestion(chatbotResponse.getBody());
             }
+            // 챗봇 시설물 조회 기능
+            case FAC -> {
+                return returnFacilityInfo(chatbotResponse.getBody());
+            }
 
         }
 
@@ -68,6 +72,21 @@ public class ChatbotServiceImpl implements ChatbotService{
     public ResponseEntity<?> returnNormalQuestion(ChatbotResDto dto){
         ToFrontResDto resDto = new ToFrontResDto(dto.getText(), null, null, null, null);
         return ResponseApi.of(ResponseStatus._CHATBOT_NORMAL_SUCCESS,resDto);
+    }
+
+    /**
+     * 챗봇 시설물 조회 기능
+     * @param dto 챗봇으로부터 받은 응답 DTO
+     * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
+     */
+    public ResponseEntity<?> returnFacilityInfo(ChatbotResDto dto){
+        ToFrontResDto resDto = new ToFrontResDto(
+                null,
+                ChatbotUrl.FACILITY_INFO_URI,
+                dto.getData().getCampus(),
+                dto.getData().getBuilding(),
+                dto.getData().getClassroom());
+        return ResponseApi.of(ResponseStatus._CHATBOT_FAC_SUCCESS,resDto);
     }
 
     /**

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/chatbot/service/ChatbotServiceImpl.java
@@ -62,10 +62,12 @@ public class ChatbotServiceImpl implements ChatbotService{
             case REPORT -> {
                 return returnReportForm(chatbotResponse.getBody());
             }
-
+            // 챗봇 자신의 신고 조회 기능
+            case MYREPORT -> {
+                return returnMyReportForm(chatbotResponse.getBody());
+            }
         }
-
-        return null;
+        throw new IllegalStateException();
     }
 
     /**
@@ -106,6 +108,19 @@ public class ChatbotServiceImpl implements ChatbotService{
                 dto.getData().getCampus(),
                 dto.getData().getBuilding(),
                 dto.getData().getClassroom());
+        return ResponseApi.of(ResponseStatus._CHATBOT_FAC_SUCCESS,resDto);
+    }
+
+    /**
+     * 챗봇 자신의 신고 조회 기능
+     * @param dto 챗봇으로부터 받은 응답 DTO
+     * @return 챗봇의 응답 DTO를 API 명세서에 맞게 바꾼 객체
+     */
+    public ResponseEntity<?> returnMyReportForm(ChatbotResDto dto){
+        ToFrontResDto resDto = new ToFrontResDto(
+                null,
+                ChatbotUrl.MYREPORT_URI,
+                null, null, null);
         return ResponseApi.of(ResponseStatus._CHATBOT_FAC_SUCCESS,resDto);
     }
 

--- a/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/common/apipayload/ResponseStatus.java
+++ b/FixSkkuBack/fixskku/src/main/java/com/skku/fixskku/common/apipayload/ResponseStatus.java
@@ -26,7 +26,14 @@ public enum ResponseStatus {
     _FACILITY_INFO_SUCCESS(OK, "망가진 시설물 정보 조회 성공"),
     //신고 관련
     _REPORT_SUCCESS(CREATED, "신고가 성공적으로 등록되었습니다."),
-    _REPORT_LIST_SUCCESS(OK, "신고가 성공적으로 조회되었습니다.");
+    _REPORT_LIST_SUCCESS(OK, "신고가 성공적으로 조회되었습니다."),
+
+    // 챗봇 관련
+    _CHATBOT_FAQ_SUCCESS(OK,"챗봇 자주 묻는 질문 응답 성공"),
+    _CHATBOT_NORMAL_SUCCESS(OK,"챗봇 일반 질문 응답 성공"),
+    _CHATBOT_FAC_SUCCESS(OK,"챗봇 망가진 시설물 정보 조회 성공"),
+    _CHATBOT_REPORT_SUCCESS(OK,"챗봇 신고 요청 성공"),
+    _CHATBOT_MYREPORT_SUCCESS(OK,"챗봇 자신의 신고 조회 성공");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 관련 이슈번호
* Closes #18

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 1일 / 5시간

## 해결하려는 문제가 무엇인가요?
* 프론트엔드와 챗봇 서버 사이에서 적절한 결과를 전달하는 파이프라인 역할의 기능을 개발한다.

## 어떻게 해결했나요?
* 앱 프론트에서 백엔드 API를 호출하면 챗봇 서버를 호출한 뒤 응답을 받아 적절한 응답으로 앱 프론트에게 응답하도록 구현하였습니다.
* 아래 경우들로 나누어 개발하였습니다. 

1. 챗봇을 통해 FAQ를 물어본 경우(프론트에서 FAQ 버튼을 클릭)
2. 일반 질문인 경우
3. 챗봇을 통해 신고하는 경우
4. 챗봇을 통해 자신의 신고를 조회하는 경우
5. 챗봇을 통해 강의실 정보를 조회하는 경우